### PR TITLE
Fix uninitialized negative flag in argument validation

### DIFF
--- a/work/src/mandatory/01_is_valid_args.c
+++ b/work/src/mandatory/01_is_valid_args.c
@@ -29,7 +29,7 @@ static bool	will_overflow(unsigned int acc, unsigned int digit, bool negative)
 
 static bool	ft_safe_atoi(const char *str)
 {
-	int				negative;
+	bool                    negative = false;
 	unsigned int	acc;
 	unsigned int	digit;
 
@@ -38,7 +38,7 @@ static bool	ft_safe_atoi(const char *str)
 	if (*str == '+' || *str == '-')
 	{
 		if (*str == '-')
-			negative = 1;
+			negative = true;
 		str++;
 	}
 	acc = 0;


### PR DESCRIPTION
## Summary
- fix uninitialized variable in `ft_safe_atoi`
- rebuild project to ensure compilation succeeds

## Testing
- `make`
- `./push_swap 2 1`

------
https://chatgpt.com/codex/tasks/task_e_687dd3a116e083208fd1798bb85ba450